### PR TITLE
2 help hyperlinks

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,8 @@
 
 <link rel="stylesheet" href="iffy.css">
 <link rel="stylesheet" href="iphy.css">
+<link rel="help" href="https://s9a.page/iffy">
+<link rel="help" href="https://webmural.dev/iffy">
 <link rel="icon" href="iffy.svg">
 <link rel="license" href="UNLICENSE.txt">
 


### PR DESCRIPTION
because this [<b>iffy</b> library](https://s9a.page/iffy) promotes sith template
